### PR TITLE
Remove duplicate setDropText implementation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -306,7 +306,6 @@ window.addEventListener('drop', async e=>{
   renderPlaylist();
   if (currentIndex < 0) await playIndex(0);
 });
-function setDropText(text){ if(!dropzone) return; dropzone.style.display='grid'; dropzone.innerHTML = `<div>${text}</div>`; }
 
 // ---------- Resize ----------
 window.addEventListener('resize', onResize);


### PR DESCRIPTION
## Summary
- Remove the duplicate `setDropText` helper in `main.js` and rely on a single shared function.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd62f1c99883229c1f006ae0c7b9dd