### PR TITLE
Add audio equalizer controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,29 @@
       <label>Beat timeline</label>
       <input id="beatToggle" type="checkbox" />
     </div>
+    <div class="panel-row" id="eqRow">
+      <label>Equalizer</label>
+      <div id="eqSliders" class="eq-sliders">
+        <div class="eq-band"><input class="eq-slider" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
+        <div class="eq-band"><input class="eq-slider" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
+      </div>
+    </div>
+    <div class="panel-row" id="eqPresetRow">
+      <label>Presets</label>
+      <div class="eq-presets">
+        <button class="eq-preset" data-preset="flat">Flat</button>
+        <button class="eq-preset" data-preset="rock">Rock</button>
+        <button class="eq-preset" data-preset="pop">Pop</button>
+      </div>
+    </div>
     <div class="panel-footer">
       <button id="clearBeats">Clear Beat Marks</button>
     </div>

--- a/src/audio.js
+++ b/src/audio.js
@@ -20,6 +20,7 @@ export class AudioReactive {
 
     this._timeData = null;
     this._spectrum = null;
+    this.filters = [];
   }
 
   async _ensureCtx() {
@@ -34,6 +35,22 @@ export class AudioReactive {
       this._spectrum = new Uint8Array(this.analyser.frequencyBinCount);
       this.gain.gain.value = 0.8;
 
+      // create EQ filters
+      const freqs = [32,64,125,250,500,1000,2000,4000,8000,16000];
+      this.filters = freqs.map(f => {
+        const bi = ctx.createBiquadFilter();
+        bi.type = 'peaking';
+        bi.frequency.value = f;
+        bi.Q = 1.0;
+        bi.gain.value = 0;
+        return bi;
+      });
+      // chain filters: source -> filters -> analyser -> gain -> destination
+      for (let i=0;i<this.filters.length-1;i++){
+        this.filters[i].connect(this.filters[i+1]);
+      }
+      const lastFilter = this.filters[this.filters.length-1];
+      lastFilter.connect(this.analyser);
       this.analyser.connect(this.gain);
       this.gain.connect(ctx.destination);
     }
@@ -65,7 +82,8 @@ export class AudioReactive {
 
     await el.play().catch(()=>{});
     const src = this.ctx.createMediaElementSource(el);
-    src.connect(this.analyser);
+    const target = this.filters[0] || this.analyser;
+    src.connect(target);
 
     this._disconnectSource();
     this.sourceNode = src;
@@ -83,7 +101,8 @@ export class AudioReactive {
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
     const src = this.ctx.createMediaStreamSource(stream);
-    src.connect(this.analyser);
+    const target = this.filters[0] || this.analyser;
+    src.connect(target);
 
     this._disconnectSource();
     this.sourceNode = src;
@@ -131,6 +150,16 @@ export class AudioReactive {
   setVolume(v) { if (this.gain) this.gain.gain.value = Math.max(0, Math.min(1, v)); }
   getVolume() { return this.gain ? this.gain.gain.value : 0; }
   setSensitivity(s) { this.sensitivity = Math.max(0.1, Math.min(4, s)); }
+
+  setEqGain(band, dB) {
+    if (!this.filters?.length) return;
+    const f = this.filters[band];
+    if (f) f.gain.value = Math.max(-12, Math.min(12, dB));
+  }
+
+  getEqSettings(){
+    return this.filters?.map(f => f.gain.value) || [];
+  }
 
   getSpectrumArray() {
     if (!this.analyser) return new Uint8Array(0);

--- a/src/main.js
+++ b/src/main.js
@@ -357,6 +357,43 @@ const filmToggle = document.getElementById('filmToggle');
 const rgbToggle = document.getElementById('rgbToggle');
 const beatToggle = document.getElementById('beatToggle');
 const clearBeatsBtn = document.getElementById('clearBeats');
+const eqSliders = Array.from(document.querySelectorAll('.eq-slider'));
+const eqPresetBtns = Array.from(document.querySelectorAll('.eq-preset'));
+
+const EQ_PRESETS = {
+  flat: new Array(10).fill(0),
+  rock: [4,3,2,1,0,0,1,2,3,4],
+  pop:  [-1,0,1,3,5,3,1,0,-1,-2]
+};
+
+function applyEq(values){
+  values.forEach((v,i)=>{
+    if(eqSliders[i]){
+      eqSliders[i].value = v;
+      audio.setEqGain(i, parseFloat(v));
+    }
+  });
+}
+function saveEq(){
+  const vals = eqSliders.map(s=> parseFloat(s.value));
+  localStorage.setItem('eqSettings', JSON.stringify(vals));
+}
+function loadEq(){
+  const stored = localStorage.getItem('eqSettings');
+  const vals = stored ? JSON.parse(stored) : EQ_PRESETS.flat;
+  audio._ensureCtx?.().then(()=> applyEq(vals));
+}
+eqSliders.forEach((sl,i)=>{
+  sl.addEventListener('input', ()=>{ audio.setEqGain(i, parseFloat(sl.value)); saveEq(); });
+});
+eqPresetBtns.forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const preset = btn.dataset.preset;
+    const vals = EQ_PRESETS[preset];
+    if(vals){ applyEq(vals); saveEq(); }
+  });
+});
+loadEq();
 
 btnSettings.addEventListener('click', ()=> {
   settingsPanel.hidden = !settingsPanel.hidden;

--- a/src/styles.css
+++ b/src/styles.css
@@ -110,3 +110,9 @@ label.vol { display: inline-flex; align-items: center; gap: 6px; color: var(--mu
 }
 .panel-row input[type="range"] { width: 160px; }
 .panel-footer { display: flex; justify-content: flex-end; }
+
+/* Equalizer */
+#eqRow .eq-sliders { width:160px; display:flex; gap:6px; align-items:flex-end; height:100px; }
+.eq-band { display:flex; flex-direction:column; align-items:center; font-size:11px; }
+.eq-band input { width:8px; height:80px; -webkit-appearance: slider-vertical; writing-mode: bt-lr; }
+.eq-presets { display:flex; gap:6px; }


### PR DESCRIPTION
## Summary
- Chain ten biquad peaking filters before the analyser and expose EQ methods
- Add equalizer section with band sliders and presets to settings panel
- Bind sliders to audio engine with localStorage persistence for EQ settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd7e12c07883229c1d4557835e9094