### PR TITLE
Fix EQ overlay start position

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -526,9 +526,12 @@ function drawMiniSpectrum(freqData){
     specCtx.globalAlpha = 1.0;
     specCtx.strokeStyle = '#ffea00';
     specCtx.lineWidth = 2;
-    specCtx.beginPath();
-    points.forEach((p,i)=>{ if(i===0) specCtx.moveTo(p.x,p.y); else specCtx.lineTo(p.x,p.y); });
-    specCtx.stroke();
+    if(points.length){
+      specCtx.beginPath();
+      specCtx.moveTo(0, points[0].y);
+      points.forEach(p=> specCtx.lineTo(p.x, p.y));
+      specCtx.stroke();
+    }
   }
 }
 function drawMiniWave(timeData){


### PR DESCRIPTION
## Summary
- Start EQ overlay line at x=0 so it begins at the left edge of the spectrum display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8aa932548322bd5f846c5ea8d5d8