### PR TITLE
feat: play song from playlist on double-click

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -298,6 +298,10 @@ function renderPlaylist(){
         await savePlaylistToDB();
       }
     });
+    li.addEventListener('dblclick', async (e)=>{
+      if (e.target.closest('button')) return;
+      await playIndex(idx);
+    });
     plList.appendChild(li);
   });
 }


### PR DESCRIPTION
## Summary
- double-clicking a playlist entry plays that track
- ignore double-clicks on inner buttons when triggering playback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd8f74985883228c62c3e71bcd0439