### PR TITLE
Gate beat ticks by frequency-band volume

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       </label>
       <button id="btnFullscreen" title="Fullscreen">⛶</button>
       <button id="btnSettings" title="Settings">⚙️</button>
+      <button id="btnBeatConfig" title="Beat Settings">🎚️</button>
       <button id="btnPlaylist" title="Toggle Playlist">📜</button>
     </div>
 
@@ -134,6 +135,49 @@
     </div>
     <div class="panel-footer">
       <button id="clearBeats">Clear Beat Marks</button>
+    </div>
+  </div>
+
+  <!-- Beat settings panel -->
+  <div id="beatPanel" class="panel" style="left:auto; right:12px;" hidden>
+    <div class="panel-title">Beat Settings</div>
+    <div class="panel-row">
+      <label>Kick range</label>
+      <div><input id="kickFrom" type="number" min="20" max="20000" value="40" style="width:60px;"> –
+      <input id="kickTo" type="number" min="20" max="20000" value="200" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Kick threshold</label>
+      <input id="kickTh" type="range" min="0" max="1" step="0.01" value="0.6" />
+      <span id="kickThVal">0.60</span>
+    </div>
+    <div class="panel-row">
+      <label>Snare low</label>
+      <div><input id="snareLowFrom" type="number" min="20" max="20000" value="120" style="width:60px;"> –
+      <input id="snareLowTo" type="number" min="20" max="20000" value="250" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Snare high</label>
+      <div><input id="snareHighFrom" type="number" min="20" max="20000" value="2000" style="width:60px;"> –
+      <input id="snareHighTo" type="number" min="20" max="20000" value="5000" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Snare threshold</label>
+      <input id="snareTh" type="range" min="0" max="1" step="0.01" value="0.5" />
+      <span id="snareThVal">0.50</span>
+    </div>
+    <div class="panel-row">
+      <label>Hat range</label>
+      <div><input id="hatFrom" type="number" min="20" max="20000" value="6000" style="width:60px;"> –
+      <input id="hatTo" type="number" min="20" max="20000" value="16000" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Hat threshold</label>
+      <input id="hatTh" type="range" min="0" max="1" step="0.01" value="0.45" />
+      <span id="hatThVal">0.45</span>
+    </div>
+    <div class="panel-footer">
+      <button id="beatClose">Close</button>
     </div>
   </div>
 

--- a/src/audio.js
+++ b/src/audio.js
@@ -194,6 +194,18 @@ export class AudioReactive {
     return this._timeData;
   }
 
+  getRangeVolume(fromHz, toHz) {
+    if (!this.analyser || !this.ctx) return 0;
+    const spec = this.getSpectrumArray();
+    const nyquist = this.ctx.sampleRate / 2;
+    const len = spec.length;
+    const start = Math.max(0, Math.floor((fromHz/nyquist) * len));
+    const end = Math.min(len, Math.ceil((toHz/nyquist) * len));
+    let sum = 0, count = 0;
+    for (let i = start; i < end; i++) { sum += spec[i]; count++; }
+    return count ? (sum / count) / 255 : 0;
+  }
+
   getBands() {
     const spec = this.getSpectrumArray();
     if (!spec.length) return { overall:0, bass:0, mid:0, treble:0 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,6 +116,7 @@ label.vol { display: inline-flex; align-items: center; gap: 6px; color: var(--mu
   box-shadow: 0 6px 24px rgba(0,0,0,0.35);
   padding: 10px 12px;
 }
+#beatPanel { left: auto; right: 12px; }
 .panel-title { font-weight: 700; margin-bottom: 8px; }
 .panel-row {
   display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px;


### PR DESCRIPTION
## Summary
- add helper to measure spectrum volume for arbitrary frequency ranges
- gate beat timeline ticks until range-specific volume thresholds are met
- expose default kick/snare/hat thresholds in settings
- add modal to adjust frequency ranges and thresholds at runtime

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8f4220ac83228ab4aca04117b191