### PR TITLE
Gate beat ticks by frequency-band volume

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       </label>
       <button id="btnFullscreen" title="Fullscreen">⛶</button>
       <button id="btnSettings" title="Settings">⚙️</button>
+      <button id="btnBeatConfig" title="Beat Settings">🎚️</button>
       <button id="btnPlaylist" title="Toggle Playlist">📜</button>
     </div>
 
@@ -40,9 +41,11 @@
       </div>
 
       <div class="leds">
-        <span id="ledKick"  class="led off">KICK</span>
-        <span id="ledSnare" class="led off">SNARE</span>
-        <span id="ledHat"   class="led off">HAT</span>
+        <span id="ledSub"     class="led off">SUB</span>
+        <span id="ledBass"    class="led off">BASS</span>
+        <span id="ledLowMid"  class="led off">LOW‑MID</span>
+        <span id="ledHighMid" class="led off">HIGH‑MID</span>
+        <span id="ledHat"     class="led off">HI‑HAT</span>
       </div>
       </div>
     </div>
@@ -134,6 +137,50 @@
     </div>
     <div class="panel-footer">
       <button id="clearBeats">Clear Beat Marks</button>
+    </div>
+  </div>
+
+  <!-- Beat settings panel -->
+  <div id="beatPanel" class="panel" style="left:auto; right:12px;" hidden>
+    <div class="panel-title">Beat Settings</div>
+    <div class="panel-row">
+      <label>Kick range</label>
+      <div><input id="kickFrom" type="number" min="20" max="20000" value="40" style="width:60px;"> –
+      <input id="kickTo" type="number" min="20" max="20000" value="200" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Kick threshold</label>
+      <input id="kickTh" type="range" min="0" max="1" step="0.01" value="0.6" />
+      <span id="kickThVal">0.60</span>
+    </div>
+    <div class="panel-row">
+      <label>Snare low</label>
+      <div><input id="snareLowFrom" type="number" min="20" max="20000" value="120" style="width:60px;"> –
+      <input id="snareLowTo" type="number" min="20" max="20000" value="250" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Snare high</label>
+      <div><input id="snareHighFrom" type="number" min="20" max="20000" value="2000" style="width:60px;"> –
+      <input id="snareHighTo" type="number" min="20" max="20000" value="5000" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Snare threshold</label>
+      <input id="snareTh" type="range" min="0" max="1" step="0.01" value="0.5" />
+      <span id="snareThVal">0.50</span>
+    </div>
+    <div class="panel-row">
+      <label>Hat range</label>
+      <div><input id="hatFrom" type="number" min="20" max="20000" value="6000" style="width:60px;"> –
+      <input id="hatTo" type="number" min="20" max="20000" value="16000" style="width:60px;"></div>
+    </div>
+    <div class="panel-row">
+      <label>Hat threshold</label>
+      <input id="hatTh" type="range" min="0" max="1" step="0.01" value="0.45" />
+      <span id="hatThVal">0.45</span>
+    </div>
+    <div class="panel-footer">
+      <button id="beatCancel">Cancel</button>
+      <button id="beatSave">Save</button>
     </div>
   </div>
 

--- a/src/audio.js
+++ b/src/audio.js
@@ -194,6 +194,18 @@ export class AudioReactive {
     return this._timeData;
   }
 
+  getRangeVolume(fromHz, toHz) {
+    if (!this.analyser || !this.ctx) return 0;
+    const spec = this.getSpectrumArray();
+    const nyquist = this.ctx.sampleRate / 2;
+    const len = spec.length;
+    const start = Math.max(0, Math.floor((fromHz/nyquist) * len));
+    const end = Math.min(len, Math.ceil((toHz/nyquist) * len));
+    let sum = 0, count = 0;
+    for (let i = start; i < end; i++) { sum += spec[i]; count++; }
+    return count ? (sum / count) / 255 : 0;
+  }
+
   getBands() {
     const spec = this.getSpectrumArray();
     if (!spec.length) return { overall:0, bass:0, mid:0, treble:0 };

--- a/src/main.js
+++ b/src/main.js
@@ -120,18 +120,32 @@ const waveCtx  = miniWave.getContext('2d');
 const dropzone = document.getElementById('dropzone');
 const btnFS = document.getElementById('btnFullscreen');
 const btnSettings = document.getElementById('btnSettings');
+const btnBeatConfig = document.getElementById('btnBeatConfig');
 
 // LEDs
-const ledKick  = document.getElementById('ledKick');
-const ledSnare = document.getElementById('ledSnare');
-const ledHat   = document.getElementById('ledHat');
-const ledTimers = { kick: 0, snare: 0, hat: 0 };
+const ledSub     = document.getElementById('ledSub');
+const ledBass    = document.getElementById('ledBass');
+const ledLowMid  = document.getElementById('ledLowMid');
+const ledHighMid = document.getElementById('ledHighMid');
+const ledHat     = document.getElementById('ledHat');
+const ledRefs = { sub: ledSub, bass: ledBass, lowMid: ledLowMid, highMid: ledHighMid, hat: ledHat };
+const ledTimers = { sub: 0, bass: 0, lowMid: 0, highMid: 0, hat: 0 };
+const LED_RANGES = {
+  sub: [40, 80],
+  bass: [80, 200],
+  lowMid: [200, 600],
+  highMid: [2000, 5000],
+  hat: [6000, 16000],
+};
+const LED_THRESHOLDS = { sub: 0.6, bass: 0.6, lowMid: 0.5, highMid: 0.5, hat: 0.45 };
 function bumpLED(which, seconds=0.15){ ledTimers[which] = Math.max(ledTimers[which], seconds); }
 function updateLEDs(dt){
-  for (const k of ['kick','snare','hat']) ledTimers[k] = Math.max(0, ledTimers[k] - dt);
-  ledKick.classList.toggle('on', ledTimers.kick>0);  ledKick.classList.toggle('off', !(ledTimers.kick>0));
-  ledSnare.classList.toggle('on', ledTimers.snare>0);ledSnare.classList.toggle('off', !(ledTimers.snare>0));
-  ledHat.classList.toggle('on', ledTimers.hat>0);    ledHat.classList.toggle('off', !(ledTimers.hat>0));
+  for (const k in ledTimers) ledTimers[k] = Math.max(0, ledTimers[k] - dt);
+  for (const k in ledRefs) {
+    const el = ledRefs[k];
+    el.classList.toggle('on', ledTimers[k] > 0);
+    el.classList.toggle('off', !(ledTimers[k] > 0));
+  }
 }
 
 // ---------- Playlist panel (IndexedDB persistence) ----------
@@ -351,6 +365,13 @@ const settings = {
   film: true,
   rgb: true,
   beatTimeline: false,
+  beatThresholds: { kick: 0.6, snare: 0.5, hat: 0.45 },
+  beatRanges: {
+    kick: [40, 200],
+    snare1: [120, 250],
+    snare2: [2000, 5000],
+    hat: [6000, 16000],
+  },
 };
 const settingsPanel = document.getElementById('settingsPanel');
 const themeSel = document.getElementById('themeSel');
@@ -363,6 +384,23 @@ const filmToggle = document.getElementById('filmToggle');
 const rgbToggle = document.getElementById('rgbToggle');
 const beatToggle = document.getElementById('beatToggle');
 const clearBeatsBtn = document.getElementById('clearBeats');
+const beatPanel = document.getElementById('beatPanel');
+const beatSave = document.getElementById('beatSave');
+const beatCancel = document.getElementById('beatCancel');
+const kickFrom = document.getElementById('kickFrom');
+const kickTo = document.getElementById('kickTo');
+const kickTh = document.getElementById('kickTh');
+const kickThVal = document.getElementById('kickThVal');
+const snareLowFrom = document.getElementById('snareLowFrom');
+const snareLowTo = document.getElementById('snareLowTo');
+const snareHighFrom = document.getElementById('snareHighFrom');
+const snareHighTo = document.getElementById('snareHighTo');
+const snareTh = document.getElementById('snareTh');
+const snareThVal = document.getElementById('snareThVal');
+const hatFrom = document.getElementById('hatFrom');
+const hatTo = document.getElementById('hatTo');
+const hatTh = document.getElementById('hatTh');
+const hatThVal = document.getElementById('hatThVal');
 const eqSliders = Array.from(document.querySelectorAll('.eq-slider'));
 const eqPresetBtns = Array.from(document.querySelectorAll('.eq-preset'));
 
@@ -430,6 +468,49 @@ eqPresetBtns.forEach(btn=>{
   });
 });
 loadEq();
+
+function syncBeatInputs(){
+  const r = settings.beatRanges;
+  kickFrom.value = r.kick[0];
+  kickTo.value = r.kick[1];
+  snareLowFrom.value = r.snare1[0];
+  snareLowTo.value = r.snare1[1];
+  snareHighFrom.value = r.snare2[0];
+  snareHighTo.value = r.snare2[1];
+  hatFrom.value = r.hat[0];
+  hatTo.value = r.hat[1];
+  kickTh.value = settings.beatThresholds.kick; kickThVal.textContent = settings.beatThresholds.kick.toFixed(2);
+  snareTh.value = settings.beatThresholds.snare; snareThVal.textContent = settings.beatThresholds.snare.toFixed(2);
+  hatTh.value = settings.beatThresholds.hat; hatThVal.textContent = settings.beatThresholds.hat.toFixed(2);
+}
+syncBeatInputs();
+
+function applyBeatInputs(){
+  const r = settings.beatRanges;
+  r.kick[0] = parseFloat(kickFrom.value)||0;
+  r.kick[1] = parseFloat(kickTo.value)||0;
+  r.snare1[0] = parseFloat(snareLowFrom.value)||0;
+  r.snare1[1] = parseFloat(snareLowTo.value)||0;
+  r.snare2[0] = parseFloat(snareHighFrom.value)||0;
+  r.snare2[1] = parseFloat(snareHighTo.value)||0;
+  r.hat[0] = parseFloat(hatFrom.value)||0;
+  r.hat[1] = parseFloat(hatTo.value)||0;
+  const th = settings.beatThresholds;
+  th.kick = parseFloat(kickTh.value)||0;
+  th.snare = parseFloat(snareTh.value)||0;
+  th.hat = parseFloat(hatTh.value)||0;
+}
+
+btnBeatConfig?.addEventListener('click', ()=> {
+  beatPanel.hidden = !beatPanel.hidden;
+  if (!beatPanel.hidden) syncBeatInputs();
+});
+beatCancel?.addEventListener('click', ()=> { syncBeatInputs(); beatPanel.hidden = true; });
+beatSave?.addEventListener('click', ()=> { applyBeatInputs(); beatPanel.hidden = true; });
+
+kickTh.addEventListener('input', ()=>{ kickThVal.textContent = (parseFloat(kickTh.value)||0).toFixed(2); });
+snareTh.addEventListener('input', ()=>{ snareThVal.textContent = (parseFloat(snareTh.value)||0).toFixed(2); });
+hatTh.addEventListener('input', ()=>{ hatThVal.textContent = (parseFloat(hatTh.value)||0).toFixed(2); });
 
 btnSettings.addEventListener('click', ()=> {
   settingsPanel.hidden = !settingsPanel.hidden;
@@ -699,7 +780,19 @@ let lastBeatAt = -10;
 function updateBeatTimeline(onsets){
   if (!settings.beatTimeline) return;
   const t = audio.getCurrentTime();
-  if (onsets.any && (t - lastBeatAt) > 0.12) { // refractory to avoid spamming
+  const r = settings.beatRanges;
+  const kickVol = audio.getRangeVolume(r.kick[0], r.kick[1]);
+  const snareVol = Math.max(
+    audio.getRangeVolume(r.snare1[0], r.snare1[1]),
+    audio.getRangeVolume(r.snare2[0], r.snare2[1])
+  );
+  const hatVol = audio.getRangeVolume(r.hat[0], r.hat[1]);
+  const th = settings.beatThresholds;
+  const hit =
+    (onsets.kick  && kickVol  >= th.kick) ||
+    (onsets.snare && snareVol >= th.snare) ||
+    (onsets.hat   && hatVol   >= th.hat);
+  if (hit && (t - lastBeatAt) > 0.12) {
     beatMarks.push(t);
     lastBeatAt = t;
   }
@@ -737,9 +830,14 @@ function tick(){
   const spectrum = audio.getSpectrumArray();
   const timeData = audio.getTimeDomainArray();
   const on = audio.getOnsets ? audio.getOnsets() : {kick:false,snare:false,hat:false,any:false};
-  if (on.kick)  bumpLED('kick');
-  if (on.snare) bumpLED('snare');
-  if (on.hat)   bumpLED('hat');
+  const lv = {
+    sub:     audio.getRangeVolume(...LED_RANGES.sub),
+    bass:    audio.getRangeVolume(...LED_RANGES.bass),
+    lowMid:  audio.getRangeVolume(...LED_RANGES.lowMid),
+    highMid: audio.getRangeVolume(...LED_RANGES.highMid),
+    hat:     audio.getRangeVolume(...LED_RANGES.hat)
+  };
+  for (const k in lv) if (lv[k] >= LED_THRESHOLDS[k]) bumpLED(k);
   updateLEDs(dt);
   const level = audio.getBands ? audio.getBands().overall : 0;
   updateVUMeter(level);

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,13 +116,14 @@ label.vol { display: inline-flex; align-items: center; gap: 6px; color: var(--mu
   box-shadow: 0 6px 24px rgba(0,0,0,0.35);
   padding: 10px 12px;
 }
+#beatPanel { left: auto; right: 12px; }
 .panel-title { font-weight: 700; margin-bottom: 8px; }
 .panel-row {
   display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px;
   margin: 8px 0;
 }
 .panel-row input[type="range"] { width: 160px; }
-.panel-footer { display: flex; justify-content: flex-end; }
+.panel-footer { display: flex; justify-content: flex-end; gap: 6px; }
 
 
 /* Equalizer panel */


### PR DESCRIPTION
## Summary
- add helper to measure spectrum volume for arbitrary frequency ranges
- gate beat timeline ticks until range-specific volume thresholds are met
- expose default kick/snare/hat thresholds in settings
- add modal to adjust frequency ranges and thresholds at runtime
- light LEDs for sub/bass/mid/high bands when their volumes cross thresholds
- add Save/Cancel controls to beat settings panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8f4220ac83228ab4aca04117b191