### PR TITLE
feat: allow bypassing equalizer for audio or LED

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -554,6 +554,8 @@ const eqPresetBtns = Array.from(document.querySelectorAll('.eq-preset'));
 const hpfSlider = document.getElementById('hpfSlider');
 const lpfSlider = document.getElementById('lpfSlider');
 const eqOverlayToggle = document.getElementById('eqOverlayToggle');
+const eqAudioToggle = document.getElementById('eqAudioToggle');
+const eqLedToggle = document.getElementById('eqLedToggle');
 
 const EQ_PRESETS = {
   flat: new Array(10).fill(0),
@@ -615,6 +617,11 @@ eqPresetBtns.forEach(btn=>{
   });
 });
 loadEq();
+
+eqAudioToggle?.addEventListener('change', ()=> audio.setEqAudioEnabled(eqAudioToggle.checked));
+eqLedToggle?.addEventListener('change', ()=> audio.setEqLedEnabled(eqLedToggle.checked));
+audio.setEqAudioEnabled(eqAudioToggle?.checked ?? true);
+audio.setEqLedEnabled(eqLedToggle?.checked ?? true);
 
 function syncBeatInputs(){
   const r = settings.beatRanges;


### PR DESCRIPTION
## Summary
- add `eqAudioEnabled` and `eqLedEnabled` to switch EQ processing for playback or LED analysis
- route audio through raw analyser node to support EQ bypass and LED toggling
- hook up EQ bypass checkboxes in main UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "jsmediatags/dist/jsmediatags.min.js")*


------
https://chatgpt.com/codex/tasks/task_e_68bda50f9b30832298144fb5543a0697