### PR TITLE
Add audio/LED toggles to equalizer panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
       <div class="eq-cuts">
         <label>HPF <input id="hpfSlider" type="range" min="20" max="1000" step="1" value="20" /></label>
         <label>LPF <input id="lpfSlider" type="range" min="1000" max="20000" step="100" value="20000" /></label>
+        <label class="eq-toggle"><input id="eqAudioToggle" type="checkbox" checked />Audio</label>
+        <label class="eq-toggle"><input id="eqLedToggle" type="checkbox" checked />LEDs</label>
         <label class="eq-overlay"><input id="eqOverlayToggle" type="checkbox" />Overlay</label>
       </div>
       <div class="eq-presets">

--- a/src/main.js
+++ b/src/main.js
@@ -586,19 +586,29 @@ function applyEq(data){
   if(eqOverlayToggle){
     eqOverlayToggle.checked = data.overlay ?? false;
   }
+  if(eqAudioToggle){
+    eqAudioToggle.checked = data.audio ?? true;
+    audio.setEqAudioEnabled(eqAudioToggle.checked);
+  }
+  if(eqLedToggle){
+    eqLedToggle.checked = data.leds ?? true;
+    audio.setEqLedEnabled(eqLedToggle.checked);
+  }
 }
 function saveEq(){
   const data = {
     gains: eqSliders.map(s=> parseFloat(s.value)),
     hpf: parseFloat(hpfSlider?.value || 20),
     lpf: parseFloat(lpfSlider?.value || 20000),
-    overlay: eqOverlayToggle?.checked || false
+    overlay: eqOverlayToggle?.checked || false,
+    audio: eqAudioToggle?.checked ?? true,
+    leds: eqLedToggle?.checked ?? true
   };
   localStorage.setItem('eqSettings', JSON.stringify(data));
 }
 function loadEq(){
   const stored = localStorage.getItem('eqSettings');
-  const data = stored ? JSON.parse(stored) : { gains: EQ_PRESETS.flat, hpf:20, lpf:20000, overlay:false };
+  const data = stored ? JSON.parse(stored) : { gains: EQ_PRESETS.flat, hpf:20, lpf:20000, overlay:false, audio:true, leds:true };
   audio._ensureCtx?.().then(()=> applyEq(data));
 }
 eqSliders.forEach((sl,i)=>{
@@ -618,10 +628,8 @@ eqPresetBtns.forEach(btn=>{
 });
 loadEq();
 
-eqAudioToggle?.addEventListener('change', ()=> audio.setEqAudioEnabled(eqAudioToggle.checked));
-eqLedToggle?.addEventListener('change', ()=> audio.setEqLedEnabled(eqLedToggle.checked));
-audio.setEqAudioEnabled(eqAudioToggle?.checked ?? true);
-audio.setEqLedEnabled(eqLedToggle?.checked ?? true);
+eqAudioToggle?.addEventListener('change', ()=>{ audio.setEqAudioEnabled(eqAudioToggle.checked); saveEq(); });
+eqLedToggle?.addEventListener('change', ()=>{ audio.setEqLedEnabled(eqLedToggle.checked); saveEq(); });
 
 function syncBeatInputs(){
   const r = settings.beatRanges;

--- a/src/styles.css
+++ b/src/styles.css
@@ -149,7 +149,7 @@ label.vol { display: inline-flex; align-items: center; gap: 6px; color: var(--mu
 .eq-cuts { display:flex; gap:10px; align-items:center; font-size:11px; }
 .eq-cuts label { display:flex; align-items:center; gap:4px; }
 .eq-presets { display:flex; gap:6px; }
-.eq-overlay { font-size:11px; display:flex; align-items:center; gap:4px; }
+.eq-overlay, .eq-toggle { font-size:11px; display:flex; align-items:center; gap:4px; }
 
 /* Playlist styles */
 #pl-list li .pl-name {


### PR DESCRIPTION
## Summary
- add Audio and LEDs checkboxes to EQ panel
- style EQ toggles
- persist audio/LED flags in EQ settings and wire to audio methods

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "jsmediatags/dist/jsmediatags.min.js")*

------
https://chatgpt.com/codex/tasks/task_e_68bda6e559e48322b8fba94695ba6e61