### PR TITLE
Add HPF/LPF filter toggles with LED routing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -663,10 +663,22 @@ eqPresetBtns.forEach(btn=>{
 });
 loadEq();
 
-hpfAudioToggle?.addEventListener('change', ()=>{ audio.setHpfAudioEnabled(hpfAudioToggle.checked); saveEq(); });
-hpfLedToggle?.addEventListener('change', ()=>{ audio.setHpfLedEnabled(hpfLedToggle.checked); saveEq(); });
-lpfAudioToggle?.addEventListener('change', ()=>{ audio.setLpfAudioEnabled(lpfAudioToggle.checked); saveEq(); });
-lpfLedToggle?.addEventListener('change', ()=>{ audio.setLpfLedEnabled(lpfLedToggle.checked); saveEq(); });
+hpfAudioToggle?.addEventListener('change', ()=>{
+  audio.setHpfAudioEnabled(hpfAudioToggle.checked); // enable/disable HPF in audio path
+  saveEq();
+});
+hpfLedToggle?.addEventListener('change', ()=>{
+  audio.setHpfLedEnabled(hpfLedToggle.checked); // use HPF data for LEDs
+  saveEq();
+});
+lpfAudioToggle?.addEventListener('change', ()=>{
+  audio.setLpfAudioEnabled(lpfAudioToggle.checked); // enable/disable LPF in audio path
+  saveEq();
+});
+lpfLedToggle?.addEventListener('change', ()=>{
+  audio.setLpfLedEnabled(lpfLedToggle.checked); // use LPF data for LEDs
+  saveEq();
+});
 eqAudioToggle?.addEventListener('change', ()=>{ audio.setEqAudioEnabled(eqAudioToggle.checked); saveEq(); });
 eqLedToggle?.addEventListener('change', ()=>{ audio.setEqLedEnabled(eqLedToggle.checked); saveEq(); });
 


### PR DESCRIPTION
## Summary
- add pre-filter analysers to support bypassing HPF/LPF for audio and LED paths
- expose setters to enable/disable HPF/LPF for audio and LED visualiser
- route LED spectrum/time-domain queries through analyser chosen by flags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import jsmediatags)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaab0ba8c83229f570e827a82cfc8