### PR TITLE
Refine LED analyser selection

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -141,10 +141,14 @@ export class AudioReactive {
 
   _getLedAnalyser() {
     if (!this.ctx) return null;
-    if (!this.hpfLedEnabled) return this.preHpfAnalyser;
-    if (!this.eqLedEnabled) return this.rawAnalyser;
-    if (!this.lpfLedEnabled) return this.preLpfAnalyser;
-    return this.analyser;
+
+    let node = this.preHpfAnalyser;
+
+    if (this.hpfAudioEnabled && this.hpfLedEnabled) node = this.rawAnalyser;
+    if (this.eqAudioEnabled && this.eqLedEnabled) node = this.preLpfAnalyser;
+    if (this.lpfAudioEnabled && this.lpfLedEnabled) node = this.analyser;
+
+    return node;
   }
 
   async useFile(file, onProgress) {


### PR DESCRIPTION
## Summary
- Ensure LED analyser selection walks through HPF → EQ → LPF chain
- Only advance when both audio and LED flags for a stage are enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "jsmediatags/dist/jsmediatags.min.js")*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bdaebbb62c8322b1422ebe095b11fd