### PR TITLE
refactor: replace custom layout classes with tailwind utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,196 +10,196 @@
   <div id="app"></div>
 
   <!-- Top HUD -->
-    <div id="appControls" class="hud">
-    <div class="row">
-      <button id="micBtn" title="Use Microphone">🎙️ Mic</button>
+    <div id="appControls" class="fixed left-3 right-3 top-3 z-[1000] grid gap-1.5 p-2.5 bg-[var(--panel)] backdrop-blur rounded-xl shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
+    <div class="flex flex-wrap items-center gap-2">
+      <button id="micBtn" title="Use Microphone" class="hover:bg-[#22365d]">🎙️ Mic</button>
       <input id="fileInput" type="file" accept="audio/*" multiple title="Add audio files"/>
-      <button id="playBtn" title="Play / Pause">⏵</button>
-      <button id="loopBtn" title="Loop Mode">🔁</button>
+      <button id="playBtn" title="Play / Pause" class="hover:bg-[#22365d]">⏵</button>
+      <button id="loopBtn" title="Loop Mode" class="hover:bg-[#22365d]">🔁</button>
       <input id="scrubber" type="range" min="0" max="0" step="0.01" value="0" />
       <span id="timeNow">0:00</span>
       <span id="timeRemain">-0:00</span>
-      <label class="vol">
+      <label class="inline-flex items-center gap-1.5 text-[var(--muted)]">
         🔊
-        <canvas id="vuMeter" width="10" height="40"></canvas>
-        <canvas id="volumeKnob" width="50" height="50"></canvas>
+        <canvas id="vuMeter" width="10" height="40" class="w-[10px] h-[40px] bg-white/10 rounded"></canvas>
+        <canvas id="volumeKnob" width="50" height="50" class="w-[50px] h-[50px] bg-white/5 rounded-full cursor-pointer"></canvas>
         <input id="volume" type="range" min="0" max="1" step="0.01" value="0.8" hidden />
         <span id="volPct">80%</span>
       </label>
-      <button id="btnFullscreen" title="Fullscreen">⛶</button>
-      <button id="btnSettings" title="Settings">⚙️</button>
-      <button id="btnBeatConfig" title="Beat Settings">🎚️</button>
-      <button id="btnPlaylist" title="Toggle Playlist">📜</button>
-      <button id="smoothToggle" title="Smooth Transition">Smooth</button>
+      <button id="btnFullscreen" title="Fullscreen" class="hover:bg-[#22365d]">⛶</button>
+      <button id="btnSettings" title="Settings" class="hover:bg-[#22365d]">⚙️</button>
+      <button id="btnBeatConfig" title="Beat Settings" class="hover:bg-[#22365d]">🎚️</button>
+      <button id="btnPlaylist" title="Toggle Playlist" class="hover:bg-[#22365d]">📜</button>
+      <button id="smoothToggle" title="Smooth Transition" class="hover:bg-[#22365d]">Smooth</button>
     </div>
 
-      <div class="row meta">
-      <span id="trackTitle">No track</span>
-      <span id="trackStatus">stopped</span>
+      <div class="flex flex-wrap items-center gap-3">
+      <span id="trackTitle" class="font-semibold text-[var(--text)]">No track</span>
+      <span id="trackStatus" class="text-[var(--muted)]">stopped</span>
 
-      <div class="meters">
-        <canvas id="miniSpec" width="260" height="60"></canvas>
-        <canvas id="miniWave" width="260" height="60"></canvas>
+      <div class="grid grid-flow-col gap-2 items-center">
+        <canvas id="miniSpec" width="260" height="60" class="w-[260px] h-[60px] bg-[rgba(255,255,255,0.03)] rounded-lg"></canvas>
+        <canvas id="miniWave" width="260" height="60" class="w-[260px] h-[60px] bg-[rgba(255,255,255,0.03)] rounded-lg"></canvas>
       </div>
 
-      <div class="leds">
-        <span id="ledSub"     class="led off">SUB</span>
-        <span id="ledBass"    class="led off">BASS</span>
-        <span id="ledLowMid"  class="led off">LOW‑MID</span>
-        <span id="ledHighMid" class="led off">HIGH‑MID</span>
-        <span id="ledHat"     class="led off">HI‑HAT</span>
+      <div class="inline-flex gap-1.5 items-center">
+        <span id="ledSub"     class="text-[11px] px-1.5 py-[3px] rounded-lg bg-[rgba(255,255,255,0.08)] text-[#b9c9ff] border border-[rgba(255,255,255,0.08)] opacity-55">SUB</span>
+        <span id="ledBass"    class="text-[11px] px-1.5 py-[3px] rounded-lg bg-[rgba(255,255,255,0.08)] text-[#b9c9ff] border border-[rgba(255,255,255,0.08)] opacity-55">BASS</span>
+        <span id="ledLowMid"  class="text-[11px] px-1.5 py-[3px] rounded-lg bg-[rgba(255,255,255,0.08)] text-[#b9c9ff] border border-[rgba(255,255,255,0.08)] opacity-55">LOW‑MID</span>
+        <span id="ledHighMid" class="text-[11px] px-1.5 py-[3px] rounded-lg bg-[rgba(255,255,255,0.08)] text-[#b9c9ff] border border-[rgba(255,255,255,0.08)] opacity-55">HIGH‑MID</span>
+        <span id="ledHat"     class="text-[11px] px-1.5 py-[3px] rounded-lg bg-[rgba(255,255,255,0.08)] text-[#b9c9ff] border border-[rgba(255,255,255,0.08)] opacity-55">HI‑HAT</span>
       </div>
       </div>
     </div>
 
     <!-- Equalizer Panel -->
-    <div id="eqPanel" class="eq-panel">
-      <div id="eqSliders" class="eq-sliders">
-        <div class="eq-band"><input class="eq-slider" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
+    <div id="eqPanel" class="fixed left-1/2 bottom-3 -translate-x-1/2 z-[1001] flex flex-col items-center gap-2 bg-[var(--panel)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
+      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]">
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
       </div>
-      <div class="eq-cuts">
-        <div class="eq-cut">
+      <div class="flex gap-2.5 items-center text-[11px]">
+        <div class="flex items-center gap-1">
           <label>HPF <input id="hpfSlider" type="range" min="20" max="1000" step="1" value="20" /></label>
-          <label class="eq-toggle"><input id="hpfAudioToggle" type="checkbox" checked />Audio</label>
-          <label class="eq-toggle"><input id="hpfLedToggle" type="checkbox" checked />LEDs</label>
+          <label class="flex items-center gap-1"><input id="hpfAudioToggle" type="checkbox" checked />Audio</label>
+          <label class="flex items-center gap-1"><input id="hpfLedToggle" type="checkbox" checked />LEDs</label>
         </div>
-        <div class="eq-cut">
+        <div class="flex items-center gap-1">
           <label>LPF <input id="lpfSlider" type="range" min="1000" max="20000" step="100" value="20000" /></label>
-          <label class="eq-toggle"><input id="lpfAudioToggle" type="checkbox" checked />Audio</label>
-          <label class="eq-toggle"><input id="lpfLedToggle" type="checkbox" checked />LEDs</label>
+          <label class="flex items-center gap-1"><input id="lpfAudioToggle" type="checkbox" checked />Audio</label>
+          <label class="flex items-center gap-1"><input id="lpfLedToggle" type="checkbox" checked />LEDs</label>
         </div>
-        <label class="eq-toggle"><input id="eqAudioToggle" type="checkbox" checked />Audio</label>
-        <label class="eq-toggle"><input id="eqLedToggle" type="checkbox" checked />LEDs</label>
-        <label class="eq-overlay"><input id="eqOverlayToggle" type="checkbox" />Overlay</label>
+        <label class="flex items-center gap-1"><input id="eqAudioToggle" type="checkbox" checked />Audio</label>
+        <label class="flex items-center gap-1"><input id="eqLedToggle" type="checkbox" checked />LEDs</label>
+        <label class="flex items-center gap-1"><input id="eqOverlayToggle" type="checkbox" />Overlay</label>
       </div>
-      <div class="eq-presets">
-        <button class="eq-preset" data-preset="flat">Flat</button>
-        <button class="eq-preset" data-preset="rock">Rock</button>
-        <button class="eq-preset" data-preset="pop">Pop</button>
+      <div class="flex gap-1.5">
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="flat">Flat</button>
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="rock">Rock</button>
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="pop">Pop</button>
       </div>
     </div>
 
     <!-- Settings panel -->
-    <div id="settingsPanel" class="panel" hidden>
-    <div class="panel-title">Settings</div>
-    <div class="panel-row">
+    <div id="settingsPanel" class="fixed left-3 bottom-3 z-[1001] w-[280px] bg-[var(--panel)] text-[var(--text)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
+    <div class="font-bold mb-2">Settings</div>
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Theme</label>
       <select id="themeSel">
         <option value="deep">Deep Blue (default)</option>
         <option value="dark">Dark Grey</option>
       </select>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Bloom</label>
       <input id="bloomStrength" type="range" min="0" max="1.2" step="0.01" value="0.55" />
       <span id="bloomVal">0.55</span>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Fog density</label>
       <input id="fogDensity" type="range" min="0" max="0.15" step="0.001" value="0.06" />
       <span id="fogVal">0.06</span>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>FXAA</label>
       <input id="fxaaToggle" type="checkbox" checked />
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Film grain</label>
       <input id="filmToggle" type="checkbox" checked />
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Chromatic ab.</label>
       <input id="rgbToggle" type="checkbox" checked />
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Beat timeline</label>
       <input id="beatToggle" type="checkbox" />
     </div>
-    <div class="panel-row" id="eqRow">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqRow">
       <label>Equalizer</label>
-      <div id="eqSliders" class="eq-sliders">
-        <div class="eq-band"><input class="eq-slider" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
-        <div class="eq-band"><input class="eq-slider" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
+      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]">
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
+        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
       </div>
     </div>
-    <div class="panel-row" id="eqPresetRow">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqPresetRow">
       <label>Presets</label>
-      <div class="eq-presets">
-        <button class="eq-preset" data-preset="flat">Flat</button>
-        <button class="eq-preset" data-preset="rock">Rock</button>
-        <button class="eq-preset" data-preset="pop">Pop</button>
+      <div class="flex gap-1.5">
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="flat">Flat</button>
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="rock">Rock</button>
+        <button class="eq-preset hover:bg-[#22365d]" data-preset="pop">Pop</button>
       </div>
     </div>
-    <div class="panel-footer">
-      <button id="clearBeats">Clear Beat Marks</button>
+    <div class="flex justify-end gap-1.5">
+      <button id="clearBeats" class="hover:bg-[#22365d]">Clear Beat Marks</button>
     </div>
   </div>
 
   <!-- Beat settings panel -->
-  <div id="beatPanel" class="panel" style="left:auto; right:12px;" hidden>
-    <div class="panel-title">Beat Settings</div>
-    <div class="panel-row">
+  <div id="beatPanel" class="fixed right-3 bottom-3 z-[1001] w-[280px] bg-[var(--panel)] text-[var(--text)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
+    <div class="font-bold mb-2">Beat Settings</div>
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Kick range</label>
-      <div><input id="kickFrom" type="number" min="20" max="20000" value="40" style="width:60px;"> –
-      <input id="kickTo" type="number" min="20" max="20000" value="200" style="width:60px;"></div>
+      <div class="flex items-center gap-1"><input id="kickFrom" type="number" min="20" max="20000" value="40" class="w-[60px]"> –
+      <input id="kickTo" type="number" min="20" max="20000" value="200" class="w-[60px]"></div>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Kick threshold</label>
       <input id="kickTh" type="range" min="0" max="1" step="0.01" value="0.6" />
       <span id="kickThVal">0.60</span>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Snare low</label>
-      <div><input id="snareLowFrom" type="number" min="20" max="20000" value="120" style="width:60px;"> –
-      <input id="snareLowTo" type="number" min="20" max="20000" value="250" style="width:60px;"></div>
+      <div class="flex items-center gap-1"><input id="snareLowFrom" type="number" min="20" max="20000" value="120" class="w-[60px]"> –
+      <input id="snareLowTo" type="number" min="20" max="20000" value="250" class="w-[60px]"></div>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Snare high</label>
-      <div><input id="snareHighFrom" type="number" min="20" max="20000" value="2000" style="width:60px;"> –
-      <input id="snareHighTo" type="number" min="20" max="20000" value="5000" style="width:60px;"></div>
+      <div class="flex items-center gap-1"><input id="snareHighFrom" type="number" min="20" max="20000" value="2000" class="w-[60px]"> –
+      <input id="snareHighTo" type="number" min="20" max="20000" value="5000" class="w-[60px]"></div>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Snare threshold</label>
       <input id="snareTh" type="range" min="0" max="1" step="0.01" value="0.5" />
       <span id="snareThVal">0.50</span>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Hat range</label>
-      <div><input id="hatFrom" type="number" min="20" max="20000" value="6000" style="width:60px;"> –
-      <input id="hatTo" type="number" min="20" max="20000" value="16000" style="width:60px;"></div>
+      <div class="flex items-center gap-1"><input id="hatFrom" type="number" min="20" max="20000" value="6000" class="w-[60px]"> –
+      <input id="hatTo" type="number" min="20" max="20000" value="16000" class="w-[60px]"></div>
     </div>
-    <div class="panel-row">
+    <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Hat threshold</label>
       <input id="hatTh" type="range" min="0" max="1" step="0.01" value="0.45" />
       <span id="hatThVal">0.45</span>
     </div>
-    <div class="panel-footer">
-      <button id="beatCancel">Cancel</button>
-      <button id="beatSave">Save</button>
-      <button id="beatClose">Close</button>
+    <div class="flex justify-end gap-1.5">
+      <button id="beatCancel" class="hover:bg-[#22365d]">Cancel</button>
+      <button id="beatSave" class="hover:bg-[#22365d]">Save</button>
+      <button id="beatClose" class="hover:bg-[#22365d]">Close</button>
     </div>
   </div>
 
   <!-- Drag & Drop Overlay -->
-  <div id="dropzone" class="dropzone" style="display:none;">
-    <div>Drop audio files to add to the playlist…</div>
+  <div id="dropzone" class="fixed inset-0 z-[1200] grid place-items-center bg-[rgba(4,10,20,0.65)] text-[18px] text-[var(--text)] pointer-events-none hidden">
+    <div class="px-[22px] py-[18px] bg-[#0e1830] border border-white/10 rounded-xl shadow-[0_8px_26px_rgba(0,0,0,0.35)]">Drop audio files to add to the playlist…</div>
   </div>
 
   <div id="coverModal"><img alt="Cover" /></div>

--- a/src/main.js
+++ b/src/main.js
@@ -154,8 +154,11 @@ function updateLEDs(dt){
   for (const k in ledTimers) ledTimers[k] = Math.max(0, ledTimers[k] - dt);
   for (const k in ledRefs) {
     const el = ledRefs[k];
-    el.classList.toggle('on', ledTimers[k] > 0);
-    el.classList.toggle('off', !(ledTimers[k] > 0));
+    const on = ledTimers[k] > 0;
+    el.classList.toggle('bg-[#6be3ff]', on);
+    el.classList.toggle('text-[#00121f]', on);
+    el.classList.toggle('border-[#89f0ff]', on);
+    el.classList.toggle('opacity-55', !on);
   }
 }
 
@@ -167,10 +170,10 @@ playlistTpl.innerHTML = `
        style="position:absolute; right:12px; z-index:1200;">
     <div class="flex gap-1.5 items-center mb-1.5">
       <strong class="flex-1">Playlist</strong>
-      <button id="pl-prev" title="Prev">⏮</button>
-      <button id="pl-next" title="Next">⏭</button>
-      <button id="pl-save" title="Save playlist">💾</button>
-      <button id="pl-load" title="Load playlist">📂</button>
+      <button id="pl-prev" title="Prev" class="hover:bg-[#22365d]">⏮</button>
+      <button id="pl-next" title="Next" class="hover:bg-[#22365d]">⏭</button>
+      <button id="pl-save" title="Save playlist" class="hover:bg-[#22365d]">💾</button>
+      <button id="pl-load" title="Load playlist" class="hover:bg-[#22365d]">📂</button>
     </div>
     <div class="flex gap-1.5 mb-1.5">
       <input id="pl-file" type="file" accept="audio/*" multiple class="flex-1" />
@@ -1018,17 +1021,17 @@ window.addEventListener('keydown', (e)=>{
 });
 
 // Drag & drop → fill playlist
-function showDrop(e){ 
+function showDrop(e){
   e.preventDefault();
-  e.stopPropagation(); 
-  if(dropzone) dropzone.style.display='grid'; 
-  console.log('show drop zone', dropzone); 
+  e.stopPropagation();
+  if(dropzone) dropzone.classList.remove('hidden');
+  console.log('show drop zone', dropzone);
 }
 
 function hideDrop(e){
   e?.preventDefault?.();
   e?.stopPropagation?.();
-  if(dropzone) dropzone.style.display='none';
+  if(dropzone) dropzone.classList.add('hidden');
   console.log('hide drop zone', dropzone);
 }
 
@@ -1052,11 +1055,11 @@ window.addEventListener('drop', async e=>{
   await savePlaylistToDB();
 });
 
-function setDropText(text){ 
-  if(!dropzone) return; 
+function setDropText(text){
+  if(!dropzone) return;
   console.log('set drop text', text);
-  dropzone.style.display='grid'; 
-  dropzone.innerHTML = `<div>${text}</div>`; 
+  dropzone.classList.remove('hidden');
+  dropzone.innerHTML = `<div>${text}</div>`;
 }
 
 // ---------- Resize ----------

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,33 +32,6 @@
 }
 
 @layer components {
-  .hud {
-    position: fixed; left: 12px; right: 12px; top: 12px;
-    z-index: 1000;
-    display: grid; gap: 6px;
-    padding: 10px;
-    background: var(--panel);
-    backdrop-filter: blur(8px);
-    border-radius: 12px;
-    box-shadow: 0 6px 24px rgba(0,0,0,0.35);
-  }
-  .hud .row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-  .hud .row.meta { gap: 12px; }
-  #trackTitle { font-weight: 600; color: var(--text); }
-  #trackStatus { color: var(--muted); }
-
-  .meters {
-    display: grid;
-    grid-auto-flow: column;
-    gap: 8px;
-    align-items: center;
-  }
-  #miniSpec, #miniWave {
-    width: 260px; height: 60px;
-    background: rgba(255,255,255,0.03);
-    border-radius: 8px;
-  }
-
   button, input[type="file"]::-webkit-file-upload-button {
     background: #1a2b4a;
     color: var(--text);
@@ -67,96 +40,7 @@
     border-radius: 8px;
     cursor: pointer;
   }
-  button:hover { background: #22365d; }
   input[type="range"] { cursor: pointer; }
-  label.vol { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
-  #vuMeter {
-    width: 10px;
-    height: 40px;
-    background: rgba(255,255,255,0.1);
-    border-radius: 4px;
-  }
-  #volumeKnob {
-    width: 50px;
-    height: 50px;
-    background: rgba(255,255,255,0.05);
-    border-radius: 50%;
-    cursor: pointer;
-  }
-
-  .dropzone {
-    position: fixed; inset: 0; z-index: 1200;
-    display: grid; place-items: center;
-    background: rgba(4,10,20,0.65);
-    color: var(--text);
-    font-size: 18px;
-    pointer-events: none;
-  }
-  .dropzone > div {
-    padding: 18px 22px;
-    background: #0e1830;
-    border: 1px solid rgba(255,255,255,0.1);
-    border-radius: 12px;
-    box-shadow: 0 8px 26px rgba(0,0,0,0.35);
-  }
-
-  .leds { display: inline-flex; gap: 6px; align-items: center; }
-  .led {
-    font-size: 11px;
-    padding: 3px 6px;
-    border-radius: 8px;
-    background: rgba(255,255,255,0.08);
-    color: #b9c9ff;
-    border: 1px solid rgba(255,255,255,0.08);
-  }
-  .led.on  { background: #6be3ff; color: #00121f; border-color: #89f0ff; }
-  .led.off { opacity: 0.55; }
-
-  /* Settings panel */
-  .panel {
-    position: fixed; left: 12px; bottom: 12px; z-index: 1001;
-    width: 280px;
-    background: var(--panel);
-    color: var(--text);
-    backdrop-filter: blur(8px);
-    border-radius: 12px;
-    box-shadow: 0 6px 24px rgba(0,0,0,0.35);
-    padding: 10px 12px;
-  }
-  #beatPanel { left: auto; right: 12px; }
-  .panel-title { font-weight: 700; margin-bottom: 8px; }
-  .panel-row {
-    display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px;
-    margin: 8px 0;
-  }
-  .panel-row input[type="range"] { width: 160px; }
-  .panel-footer { display: flex; justify-content: flex-end; gap: 6px; }
-
-  /* Equalizer panel */
-  .eq-panel {
-    position: fixed;
-    left: 50%;
-    bottom: 12px;
-    transform: translateX(-50%);
-    z-index: 1001;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    background: var(--panel);
-    backdrop-filter: blur(8px);
-    border-radius: 12px;
-    padding: 10px 12px;
-    box-shadow: 0 6px 24px rgba(0,0,0,0.35);
-  }
-  .eq-sliders { display:flex; gap:6px; align-items:flex-end; height:100px; }
-  .eq-band { display:flex; flex-direction:column; align-items:center; font-size:11px; }
-  .eq-band input { width:8px; height:80px; -webkit-appearance: slider-vertical; writing-mode: bt-lr; }
-  .eq-cuts { display:flex; gap:10px; align-items:center; font-size:11px; }
-  .eq-cuts label { display:flex; align-items:center; gap:4px; }
-  .eq-cut { display:flex; align-items:center; gap:4px; }
-  .eq-presets { display:flex; gap:6px; }
-  .eq-overlay, .eq-toggle { font-size:11px; display:flex; align-items:center; gap:4px; }
 
   #coverModal {
     position: fixed;


### PR DESCRIPTION
## Summary
- swap bespoke HUD and panel classes for Tailwind utilities
- drop unused CSS component rules
- update LED and drag-and-drop scripts to toggle Tailwind classes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bdd63786088322b049de7e788e2d7c