### PR TITLE
feat: add deep and dark palettes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./src/styles.css">
 </head>
-<body>
+<body class="bg-deep-bg text-deep-text dark:bg-dark-bg dark:text-dark-text">
   <div id="app"></div>
 
   <!-- Top HUD -->
-    <div id="appControls" class="fixed left-3 right-3 top-3 z-[1000] grid gap-1.5 p-2.5 bg-[var(--panel)] backdrop-blur rounded-xl shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
+    <div id="appControls" class="fixed left-3 right-3 top-3 z-[1000] grid gap-1.5 p-2.5 bg-deep-panel dark:bg-dark-panel backdrop-blur rounded-xl shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
     <div class="flex flex-wrap items-center gap-2">
       <button id="micBtn" title="Use Microphone" class="hover:bg-[#22365d]">🎙️ Mic</button>
       <input id="fileInput" type="file" accept="audio/*" multiple title="Add audio files"/>
@@ -19,7 +19,7 @@
       <input id="scrubber" type="range" min="0" max="0" step="0.01" value="0" />
       <span id="timeNow">0:00</span>
       <span id="timeRemain">-0:00</span>
-      <label class="inline-flex items-center gap-1.5 text-[var(--muted)]">
+      <label class="inline-flex items-center gap-1.5 text-deep-muted dark:text-dark-muted">
         🔊
         <canvas id="vuMeter" width="10" height="40" class="w-[10px] h-[40px] bg-white/10 rounded"></canvas>
         <canvas id="volumeKnob" width="50" height="50" class="w-[50px] h-[50px] bg-white/5 rounded-full cursor-pointer"></canvas>
@@ -34,8 +34,8 @@
     </div>
 
       <div class="flex flex-wrap items-center gap-3">
-      <span id="trackTitle" class="font-semibold text-[var(--text)]">No track</span>
-      <span id="trackStatus" class="text-[var(--muted)]">stopped</span>
+      <span id="trackTitle" class="font-semibold text-deep-text dark:text-dark-text">No track</span>
+      <span id="trackStatus" class="text-deep-muted dark:text-dark-muted">stopped</span>
 
       <div class="grid grid-flow-col gap-2 items-center">
         <canvas id="miniSpec" width="260" height="60" class="w-[260px] h-[60px] bg-[rgba(255,255,255,0.03)] rounded-lg"></canvas>
@@ -53,7 +53,7 @@
     </div>
 
     <!-- Equalizer Panel -->
-    <div id="eqPanel" class="fixed left-1/2 bottom-3 -translate-x-1/2 z-[1001] flex flex-col items-center gap-2 bg-[var(--panel)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
+    <div id="eqPanel" class="fixed left-1/2 bottom-3 -translate-x-1/2 z-[1001] flex flex-col items-center gap-2 bg-deep-panel dark:bg-dark-panel backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
       <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]">
         <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
         <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr]" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
@@ -89,7 +89,7 @@
     </div>
 
     <!-- Settings panel -->
-    <div id="settingsPanel" class="fixed left-3 bottom-3 z-[1001] w-[280px] bg-[var(--panel)] text-[var(--text)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
+    <div id="settingsPanel" class="fixed left-3 bottom-3 z-[1001] w-[280px] bg-deep-panel dark:bg-dark-panel text-deep-text dark:text-dark-text backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
     <div class="font-bold mb-2">Settings</div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Theme</label>
@@ -153,7 +153,7 @@
   </div>
 
   <!-- Beat settings panel -->
-  <div id="beatPanel" class="fixed right-3 bottom-3 z-[1001] w-[280px] bg-[var(--panel)] text-[var(--text)] backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
+  <div id="beatPanel" class="fixed right-3 bottom-3 z-[1001] w-[280px] bg-deep-panel dark:bg-dark-panel text-deep-text dark:text-dark-text backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]" hidden>
     <div class="font-bold mb-2">Beat Settings</div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2">
       <label>Kick range</label>
@@ -198,7 +198,7 @@
   </div>
 
   <!-- Drag & Drop Overlay -->
-  <div id="dropzone" class="fixed inset-0 z-[1200] grid place-items-center bg-[rgba(4,10,20,0.65)] text-[18px] text-[var(--text)] pointer-events-none hidden">
+  <div id="dropzone" class="fixed inset-0 z-[1200] grid place-items-center bg-[rgba(4,10,20,0.65)] text-[18px] text-deep-text dark:text-dark-text pointer-events-none hidden">
     <div class="px-[22px] py-[18px] bg-[#0e1830] border border-white/10 rounded-xl shadow-[0_8px_26px_rgba(0,0,0,0.35)]">Drop audio files to add to the playlist…</div>
   </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,29 +3,12 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --bg: #05122f;        /* deep theme */
-    --bg-2: #06122c;
-    --panel: rgba(13, 19, 33, 0.75);
-    --text: #e8f0ff;
-    --muted: #9fb7d9;
-    --accent: #8fb3ff;
-  }
-  html.dark {
-    --bg: #0a0a0a;        /* dark theme */
-    --bg-2: #141414;
-    --panel: rgba(20,20,20,0.78);
-    --text: #f2f2f2;
-    --muted: #b8b8b8;
-    --accent: #9cc0ff;
-  }
-
   html, body {
     padding: 0;
     height: 100%;
     margin: 0;
-    background: var(--bg);
-    color: var(--text);
+  }
+  body {
     font: 14px/1.4 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial;
   }
   #app { position: fixed; inset: 0; }
@@ -34,7 +17,6 @@
 @layer components {
   button, input[type="file"]::-webkit-file-upload-button {
     background: #1a2b4a;
-    color: var(--text);
     border: none;
     padding: 6px 10px;
     border-radius: 8px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,23 @@
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "deep-bg": "#05122f",
+        "deep-bg2": "#06122c",
+        "deep-panel": "#0d1321bf",
+        "deep-text": "#e8f0ff",
+        "deep-muted": "#9fb7d9",
+        "deep-accent": "#8fb3ff",
+        "dark-bg": "#0a0a0a",
+        "dark-bg2": "#141414",
+        "dark-panel": "#141414c7",
+        "dark-text": "#f2f2f2",
+        "dark-muted": "#b8b8b8",
+        "dark-accent": "#9cc0ff",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind with custom deep and dark color palettes and enable dark mode
- swap CSS variables in templates for Tailwind color utilities
- streamline base styles for body and panels

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdd91b1ca08322b1641a3c579bd2e6