### PR TITLE
refactor eq sliders into template

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
 <body class="bg-deep-bg text-deep-text dark:bg-dark-bg dark:text-dark-text">
   <div id="app"></div>
 
+  <template id="eqSliderTemplate">
+    <div class="flex flex-col items-center text-xs">
+      <input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" />
+      <span></span>
+    </div>
+  </template>
+
   <!-- Top HUD -->
     <div id="appControls" class="fixed left-3 right-3 top-3 z-[1000] grid gap-1.5 p-2.5 bg-deep-panel dark:bg-dark-panel backdrop-blur rounded-xl shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
     <div class="flex flex-wrap items-center gap-2">
@@ -54,18 +61,7 @@
 
     <!-- Equalizer Panel -->
     <div id="eqPanel" class="fixed left-1/2 bottom-3 -translate-x-1/2 z-[1001] flex flex-col items-center gap-2 bg-deep-panel dark:bg-dark-panel backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
-      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]">
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
-      </div>
+      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]"></div>
       <div class="flex gap-2.5 items-center text-[11px]">
         <div class="flex items-center gap-1">
           <label>HPF <input id="hpfSlider" type="range" min="20" max="1000" step="1" value="20" class="cursor-pointer" /></label>
@@ -126,18 +122,7 @@
     </div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqRow">
       <label>Equalizer</label>
-      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]">
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="0" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>32</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="1" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>64</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="2" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>125</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="3" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>250</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="4" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>500</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="5" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>1k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="6" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>2k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="7" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>4k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="8" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>8k</span></div>
-        <div class="flex flex-col items-center text-[11px]"><input class="eq-slider w-2 h-20 [appearance:slider-vertical] [writing-mode:bt-lr] cursor-pointer" data-band="9" type="range" min="-12" max="12" step="0.1" value="0" orient="vertical" /><span>16k</span></div>
-      </div>
+      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]"></div>
     </div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqPresetRow">
       <label>Presets</label>

--- a/src/main.js
+++ b/src/main.js
@@ -608,6 +608,26 @@ const hatFrom = document.getElementById('hatFrom');
 const hatTo = document.getElementById('hatTo');
 const hatTh = document.getElementById('hatTh');
 const hatThVal = document.getElementById('hatThVal');
+
+const EQ_FREQUENCIES = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000];
+
+function buildEqSliders() {
+  const tpl = document.getElementById('eqSliderTemplate');
+  if (!tpl) return;
+  document.querySelectorAll('#eqSliders').forEach(container => {
+    EQ_FREQUENCIES.forEach((f, i) => {
+      const node = tpl.content.firstElementChild.cloneNode(true);
+      const input = node.querySelector('input');
+      const label = node.querySelector('span');
+      input.dataset.band = i;
+      label.textContent = f >= 1000 ? `${f / 1000}k` : `${f}`;
+      container.appendChild(node);
+    });
+  });
+}
+
+buildEqSliders();
+
 const eqSliders = Array.from(document.querySelectorAll('.eq-slider'));
 const eqPresetBtns = Array.from(document.querySelectorAll('.eq-preset'));
 


### PR DESCRIPTION
## Summary
- add reusable Tailwind eq slider template
- generate slider blocks dynamically and remove redundant markup

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bde162f040832284c003d41320d7b4