### PR TITLE
Use shared class for equalizer slider containers

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
     <!-- Equalizer Panel -->
     <div id="eqPanel" class="fixed left-1/2 bottom-3 -translate-x-1/2 z-[1001] flex flex-col items-center gap-2 bg-deep-panel dark:bg-dark-panel backdrop-blur rounded-xl px-3 py-2.5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
-      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]"></div>
+      <div class="eq-sliders flex gap-1.5 items-end h-[100px]"></div>
       <div class="flex gap-2.5 items-center text-[11px]">
         <div class="flex items-center gap-1">
           <label>HPF <input id="hpfSlider" type="range" min="20" max="1000" step="1" value="20" class="cursor-pointer" /></label>
@@ -122,7 +122,7 @@
     </div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqRow">
       <label>Equalizer</label>
-      <div id="eqSliders" class="flex gap-1.5 items-end h-[100px]"></div>
+      <div class="eq-sliders flex gap-1.5 items-end h-[100px]"></div>
     </div>
     <div class="grid grid-cols-[1fr_auto] items-center gap-2.5 my-2" id="eqPresetRow">
       <label>Presets</label>

--- a/src/main.js
+++ b/src/main.js
@@ -613,7 +613,7 @@ const EQ_FREQUENCIES = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000];
 function buildEqSliders() {
   const tpl = document.getElementById('eqSliderTemplate');
   if (!tpl) return;
-  document.querySelectorAll('#eqSliders').forEach(container => {
+  document.querySelectorAll('.eq-sliders').forEach(container => {
     EQ_FREQUENCIES.forEach((f, i) => {
       const node = tpl.content.firstElementChild.cloneNode(true);
       const input = node.querySelector('input');


### PR DESCRIPTION
## Summary
- Replace duplicate `id="eqSliders"` with shared `eq-sliders` class
- Query all `.eq-sliders` containers when building equalizer UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `node <<'NODE' ... NODE`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c184a401b0832283659e831c35b1b0