### PR TITLE
refactor: expose audio context initialization

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -35,7 +35,7 @@ export class AudioReactive {
     this.lpfLedEnabled = true;
   }
 
-  async _ensureCtx() {
+  async ensureContext() {
     if (!this.ctx) {
       const ctx = new (window.AudioContext || window.webkitAudioContext)();
       this.ctx = ctx;
@@ -162,7 +162,7 @@ export class AudioReactive {
   }
 
   async useFile(file, onProgress) {
-    await this._ensureCtx();
+    await this.ensureContext();
     if (this.isMicActive && this.isMicActive()) await this.stopMic();
 
     const url = URL.createObjectURL(file);
@@ -202,7 +202,7 @@ export class AudioReactive {
   }
 
   async useMic() {
-    await this._ensureCtx();
+    await this.ensureContext();
     if (this.media?.el) { try { this.media.el.pause(); } catch {} }
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });

--- a/src/main.js
+++ b/src/main.js
@@ -481,7 +481,7 @@ plLoad.addEventListener('click', loadPlaylistFromDB);
 
 async function playIndex(i){
   const item = playlist[i]; if (!item) return;
-  await audio._ensureCtx?.();
+  await audio.ensureContext();
   const g = audio.gain?.gain;
   const startVol = audio.getVolume();
 
@@ -724,7 +724,7 @@ function loadEq(){
     audio:true,
     leds:true
   };
-  audio._ensureCtx?.().then(()=> applyEq(data));
+  audio.ensureContext().then(()=> applyEq(data));
 }
 eqSliders.forEach((sl,i)=>{
   sl.addEventListener('input', ()=>{ audio.setEqGain(i, parseFloat(sl.value)); saveEq(); });
@@ -975,7 +975,7 @@ function updateVUMeter(level){
 // ---------- UI events ----------
 micBtn.addEventListener('click', async () => {
   try{
-    await audio._ensureCtx?.();
+    await audio.ensureContext();
     if (audio.isMicActive && audio.isMicActive()){
       await audio.stopMic(); micBtn.textContent='🎙️ Mic';
     } else {


### PR DESCRIPTION
## Summary
- rename private `_ensureCtx` to public `ensureContext`
- update internal and external callers to await `ensureContext` before applying EQ or mic operations

## Testing
- `npm test` *(fails: missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18e991a688322b6772671715bd197